### PR TITLE
Fix segfaults due to incorrect null termination of occurrence structures

### DIFF
--- a/probSAT.c
+++ b/probSAT.c
@@ -287,6 +287,7 @@ static inline void parseFile() {
 
 	for (i = 0; i < numLiterals + 1; i++) {
 		occurrence[i] = (int*) malloc(sizeof(int) * (numOccurrenceT[i] + 1));
+		occurrence[i][numOccurrenceT[i]] = 0; //sentinal at the end!
 		if (numOccurrenceT[i] > maxNumOccurences)
 			maxNumOccurences = numOccurrenceT[i];
 	}


### PR DESCRIPTION
Running probSAT with gcc 4.8.4 on Ubuntu 14.04LTS caused segfaults.  Debugging led me to the occurence structures which were not being correctly null terminated for all literals (It appears that only the last literal of each clause was being correctly null-terminated).
